### PR TITLE
Correct Boards Manager install instructions

### DIFF
--- a/docs/arduino-ide/boards_manager.md
+++ b/docs/arduino-ide/boards_manager.md
@@ -1,11 +1,11 @@
 ## Installation instructions using Arduino IDE Boards Manager
 ### ==========================================================
 
-- Stable release link: `https://raw.githubusercontent.com/KMTech-id/Mappi32/package/package_kmtech_index.json`
+- Stable release link: `https://raw.githubusercontent.com/KMTech-id/Mappi32/refs/heads/master/package/package_mappi_index.json`
 
 Starting with 1.6.4, Arduino allows installation of third-party platform packages using Boards Manager. We have packages available for Windows, Mac OS, and Linux (32, 64 bit and ARM).
 
 - Install the current upstream Arduino IDE at the 1.8 level or later. The current version is at the [Arduino website](http://www.arduino.cc/en/main/software).
 - Start Arduino and open Preferences window.
 - Enter one of the release links above into *Additional Board Manager URLs* field. You can add multiple URLs, separating them with commas.
-- Open Boards Manager from Tools > Board menu and install *KMTech* platform (and don't forget to select your KMTech board from Tools > Board menu after installation).
+- Open Boards Manager from Tools > Board menu and install *Mappi32* platform (and don't forget to select your KMTech board from Tools > Board menu after installation).


### PR DESCRIPTION
Previously, the instructions specified an invalid URL. This would cause Arduino IDE to fail to download the package index file.

Additionally, the instructions specified an incorrect platform name:

https://github.com/KMTech-id/Mappi32/blob/881c8535bf1df3b806832114deb28de972b0e1ba/package/package_mappi_index.json#L45

